### PR TITLE
Allow building with mmorph-1.1.0

### DIFF
--- a/ChannelT.cabal
+++ b/ChannelT.cabal
@@ -17,9 +17,9 @@ library
   hs-source-dirs:      src
   exposed-modules:     Control.Monad.Channel.Internal
                      , Control.Monad.Channel
-  -- other-modules:       
+  -- other-modules:
   build-depends:       base >= 4.8.2.0 && < 5
                      , mtl >= 2.2.1 && < 2.3
                      , free >= 4.12.4 && < 4.13
                      , transformers-base >= 0.4.4 && < 0.5
-                     , mmorph >= 1.0.5 && < 1.1
+                     , mmorph >= 1.0.5 && < 1.2

--- a/src/Control/Monad/Channel/Internal.hs
+++ b/src/Control/Monad/Channel/Internal.hs
@@ -17,7 +17,7 @@ instance Functor f => MFunctor (FreeT f) where
 deriving instance Generic (FreeT f m a)
 
 newtype ChannelT sel m a = ChannelT { unChannelT :: FreeT (ChannelF sel) m a }
-  deriving (Functor, Applicative, Monad, MFunctor, MonadTrans, MonadFree (ChannelF sel), Generic1, Generic)
+  deriving (Functor, Applicative, Monad, MonadTrans, MonadFree (ChannelF sel), Generic1, Generic)
 deriving instance MonadBase b m => MonadBase b (ChannelT sel m)
 
 data ChannelF (sel :: * -> * -> *) (x :: *) =
@@ -33,5 +33,10 @@ class Monad m => MonadChannel (sel :: * -> * -> *) (m :: * -> *) | m -> sel wher
 
 instance Monad m => MonadChannel sel (ChannelT sel m) where
   syncOn s o = ChannelT . FreeT . return . Free . SyncChannel s o $ FreeT . return . Pure
+
+-- NB: Don't use GeneralizedNewtypeDeriving to create this instance, as it will
+-- trigger GHC Trac #11837 on GHC 8.0.1 and older.
+instance MFunctor (ChannelT sel) where
+  hoist f = ChannelT . hoist f . unChannelT
 
 type Channel sel = ChannelT sel Identity


### PR DESCRIPTION
It's not quite sufficient to just bump the upper version bounds, since on GHC 8.0.1 and older, you'll run into a bug resulting from the interaction between `MFunctor` (which became poly-kinded in `mmorph-1.1.0`) and `GeneralizedNewtypeDeriving` (see https://github.com/Gabriel439/Haskell-MMorph-Library/issues/32 and [GHC Trac #11837](https://ghc.haskell.org/trac/ghc/ticket/11837)). To work around this, I just write the `MFunctor` instance for `ChannelT` by hand.