### PR TITLE
Allow mtl-2.3 and mmorph-1.2

### DIFF
--- a/ChannelT.cabal
+++ b/ChannelT.cabal
@@ -23,7 +23,7 @@ library
                      , Control.Monad.Channel
   -- other-modules:
   build-depends:       base >= 4.8.2.0 && < 5
-                     , mtl >= 2.2.1 && < 2.3
+                     , mtl >= 2.2.1 && < 2.4
                      , free >= 5 && < 6
                      , transformers-base >= 0.4.4 && < 0.5
-                     , mmorph >= 1.0.5 && < 1.2
+                     , mmorph >= 1.0.5 && < 1.3


### PR DESCRIPTION
As a Hackage trustee I made a matching revision: https://hackage.haskell.org/package/ChannelT-0.0.0.7/revisions/